### PR TITLE
rudimentary slack parser

### DIFF
--- a/dev/slack-compatible-notification-example.json
+++ b/dev/slack-compatible-notification-example.json
@@ -1,0 +1,13 @@
+{
+  "channel": "#channel",
+  "icon_emoji": ":heart:",
+  "username": "Flux Deployer",
+  "attachments": [
+    {
+      "color": "#4286f4",
+      "title": "Applied flux changes to cluster",
+      "title_link": "https://GITURL/USERNAME/kubernetes/commit/COMMITSHA",
+      "text": "Event: Sync: 0f34755, jabber:deployment/test\nCommits:\n\n* \u003chttps://GITURL/USERNAME/kubernetes/commit/COMMITSHA\u003e: change test to test webhook\n\nResources updated:\n\n* jabber:deployment/test"
+    }
+  ]
+}

--- a/handler.go
+++ b/handler.go
@@ -7,12 +7,12 @@ import (
 )
 
 type Response struct {
-   Message string
-   Code    int
+	Message string
+	Code    int
 }
 
-func errorResponse() (Response) {
-   return Response{"", http.StatusInternalServerError}
+func errorResponse() Response {
+	return Response{"", http.StatusInternalServerError}
 }
 
 // interface for parser functions (grafana, prometheus, ...)
@@ -33,7 +33,7 @@ func (h *messageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// send message to xmpp client
 	h.messages <- m
 	w.WriteHeader(response.Code)
-   w.Write( []byte(response.Message) )
+	w.Write([]byte(response.Message))
 }
 
 // returns new handler with a given parser function
@@ -84,26 +84,26 @@ func grafanaParserFunc(r *http.Request) (string, error, Response) {
 SLACK PARSER
 *************/
 type SlackMessage struct {
-   Channel     string            `json:"channel"`
-   IconEmoji   string            `json:"icon_emoji"`
-   Username    string            `json:"username"`
-   Text        string            `json:"text"`
-   Attachments []SlackAttachment `json:"attachments"`
+	Channel     string            `json:"channel"`
+	IconEmoji   string            `json:"icon_emoji"`
+	Username    string            `json:"username"`
+	Text        string            `json:"text"`
+	Attachments []SlackAttachment `json:"attachments"`
 }
 
 type SlackAttachment struct {
-   Color       string            `json:"color"`
-   Title       string            `json:"title"`
-   TitleLink   string            `json:"title_link"`
-   Text        string            `json:"text"`
+	Color     string `json:"color"`
+	Title     string `json:"title"`
+	TitleLink string `json:"title_link"`
+	Text      string `json:"text"`
 }
 
-func nonemptyAppendNewline(message string) (string) {
-   if len(message) == 0 {
-      return message
-   }
+func nonemptyAppendNewline(message string) string {
+	if len(message) == 0 {
+		return message
+	}
 
-   return message+"\n"
+	return message + "\n"
 }
 
 func slackParserFunc(r *http.Request) (string, error, Response) {
@@ -123,19 +123,18 @@ func slackParserFunc(r *http.Request) (string, error, Response) {
 	}
 
 	// contruct alert message
-   message := ""
-   hasText := (alert.Text != "")
-   if hasText {
-      message = alert.Text
-   }
+	message := ""
+	hasText := (alert.Text != "")
+	if hasText {
+		message = alert.Text
+	}
 
-   for _, attachment := range alert.Attachments {
-      message = nonemptyAppendNewline(message)
-      message += attachment.Title+"\n"
-      message += attachment.TitleLink+"\n\n"
-      message += attachment.Text
-   }
-
+	for _, attachment := range alert.Attachments {
+		message = nonemptyAppendNewline(message)
+		message += attachment.Title + "\n"
+		message += attachment.TitleLink + "\n\n"
+		message += attachment.Text
+	}
 
 	return message, nil, Response{"ok", http.StatusOK}
 }

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func main() {
 			// create reply with identical contents
 			reply := MessageBody{
 				Message: stanza.Message{
-					To: msg.From.Bare(),
+					To:   msg.From.Bare(),
 					From: address,
 				},
 				Body: msg.Body,
@@ -139,7 +139,7 @@ func main() {
 				// try to send message, ignore errors
 				_ = xmppSession.Encode(MessageBody{
 					Message: stanza.Message{
-						To: recipient,
+						To:   recipient,
 						From: address,
 					},
 					Body: m,

--- a/main.go
+++ b/main.go
@@ -148,6 +148,7 @@ func main() {
 
 	// initialize handler for grafana alerts
 	http.Handle("/grafana", newMessageHandler(messages, grafanaParserFunc))
+	http.Handle("/slack", newMessageHandler(messages, slackParserFunc))
 
 	// listen for requests
 	http.ListenAndServe(":4321", nil)

--- a/main.go
+++ b/main.go
@@ -115,6 +115,7 @@ func main() {
 			reply := MessageBody{
 				Message: stanza.Message{
 					To: msg.From.Bare(),
+					From: address,
 				},
 				Body: msg.Body,
 			}
@@ -139,6 +140,7 @@ func main() {
 				_ = xmppSession.Encode(MessageBody{
 					Message: stanza.Message{
 						To: recipient,
+						From: address,
 					},
 					Body: m,
 				})


### PR DESCRIPTION
This is my attempt at a `Slack Incoming Webhook` parser. It is just a quick hack so I can receive notifications from justinbarrick/fluxcloud whenever a deploy happens in my kubernetes cluster.

This is also my first time writing anything in go, so sorry about the code quality. It does however pass on the webhook messages so someone might find this useful

Things to note:
- I had to add a `From: ` entry to the stanza.MessageBody instances. Otherwise my server would not deliver any messages to me
- Slack requires a response of code 200, plain text `ok` so I added a new `Response` object to the return of the parserFunc.  
  This seems like an ugly change since go functions seem to work with the err code mixed in there however I couldn't figure out the proper go way of doing this. And as before it works so it might be useful
- fluxcloud sends the notification in a single attachment. I tried to code for other message formats but I'm sure there are some messages which can not be parsed yet.